### PR TITLE
make sure npm run static work on Mac OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "static":"start http://localhost:8080/static && http-server",
+    "static":"open http://localhost:8080/static && http-server",
     "build": "react-scripts build",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
just trying out your tutorial and I was already stuck on first step. `npm run static` 

I'm on mac OSX so maybe that's why it's not working. But this PR works for me. 
